### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,19 @@
-#Summary
+# Summary
 A saner (and geekier!) approach to working with APIs.
 
-#Background
+# Background
 For background info, see the [blog post](http://thisblog.rules.io/blog/2012/12/06/the-last-gem-you-will-ever-need/) and the [wiki](https://github.com/rulesio/geekier/wiki/Home).
 
-#API Descriptions
+# API Descriptions
 In the api_descriptions directory you can find a set of description files that are language agnostic and supposed to be used with an API factory
 
-#API Factories
+# API Factories
 The job of API factories is to turn the machine-readable api description into objects (or data structures and a set of functions) that can then be used to talk to the configured API.
 
-##Ruby
+## Ruby
 Here you can find the [ruby implementation of the factory](https://github.com/rulesio/geekier_factory_gem)
 
-#Participate
+# Participate
 Please join us in the [Geekier Google group](https://groups.google.com/d/forum/geekier-apis)
 
 Also feel free to contribute to the api_description folder - by forking and sending pull requests for example - and to provide more implementations of API factories so that everyone can play.


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
